### PR TITLE
Add badges and Cargo.toml meta fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,10 @@ version = "0.1.0"
 authors = ["Dan Reeves <hey@danreev.es>"]
 repository = "https://github.com/danreeves/cargo-cmd"
 license = "MIT"
+license-file = "LICENSE"
 readme = "README.md"
 categories = ["development-tools::cargo-plugins"]
+keywords = ["cargo", "cmd", "scripts", "commands", "npm"]
 
 [dependencies]
 toml = "0.4.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Dan Reeves <hey@danreev.es>"]
 repository = "https://github.com/danreeves/cargo-cmd"
 license = "MIT"
 readme = "README.md"
-categories = ["cargo", "command-line-utilities"]
+categories = ["development-tools::cargo-plugins"]
 
 [dependencies]
 toml = "0.4.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ version = "0.1.0"
 authors = ["Dan Reeves <hey@danreev.es>"]
 repository = "https://github.com/danreeves/cargo-cmd"
 license = "MIT"
+readme = "README.md"
+categories = ["cargo", "command-line-utilities"]
 
 [dependencies]
 toml = "0.4.6"
@@ -15,3 +17,6 @@ subprocess = "0.1.13"
 [package.metadata.commands]
 greet = "echo 'Hello, planet!'"
 dev = "cargo watch -s 'clear; cargo build && cargo cmd greet'"
+
+[badges]
+travis-ci = { repository = "danreeves/cargo-cmd", branch = "master" }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # cargo-cmd
 
+[![crates.io version][1]][2]
+[![build status][3]][4]
+[![downloads][5]][6]
+[![docs.rs docs][7]][8]
+[![license](9)][10]
+
 Like `npm` scripts, but for `cargo`.
 
 ## Installation
@@ -27,3 +33,17 @@ Hello, planet!
 
 ## License
 [MIT © Dan Reeves](./LICENSE)
+
+
+
+[1]: https://img.shields.io/crates/v/cargo-cmd.svg?style=flat-square
+[2]: https://crates.io/crates/cargo-cmd
+[3]: https://img.shields.io/travis/danreeves/cargo-cmd.svg?style=flat-square
+[4]: https://travis-ci.org/danreeves/cargo-cmd
+[5]: https://img.shields.io/crates/d/cargo-cmd.svg?style=flat-square
+[6]: https://crates.io/crates/cargo-cmd
+[7]: https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square
+[8]: https://docs.rs/cargo-cmd
+[9]: https://img.shields.io/crates/l/cargo-cmd.svg?style=flat-square
+[10]: ./LICENSE
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![build status][3]][4]
 [![downloads][5]][6]
 [![docs.rs docs][7]][8]
-[![license](9)][10]
+[![license][9]][10]
 
 Like `npm` scripts, but for `cargo`.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [![crates.io version][1]][2]
 [![build status][3]][4]
-[![downloads][5]][6]
-[![docs.rs docs][7]][8]
-[![license][9]][10]
+[![docs.rs docs][5]][6]
+[![license][7]][8]
 
 Like `npm` scripts, but for `cargo`.
 
@@ -40,10 +39,8 @@ Hello, planet!
 [2]: https://crates.io/crates/cargo-cmd
 [3]: https://img.shields.io/travis/danreeves/cargo-cmd.svg?style=flat-square
 [4]: https://travis-ci.org/danreeves/cargo-cmd
-[5]: https://img.shields.io/crates/d/cargo-cmd.svg?style=flat-square
-[6]: https://crates.io/crates/cargo-cmd
-[7]: https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square
-[8]: https://docs.rs/cargo-cmd
-[9]: https://img.shields.io/crates/l/cargo-cmd.svg?style=flat-square
-[10]: ./LICENSE
+[5]: https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square
+[6]: https://docs.rs/cargo-cmd
+[7]: https://img.shields.io/crates/l/cargo-cmd.svg?style=flat-square
+[8]: ./LICENSE
 


### PR DESCRIPTION
Provide easy access and visibility to the crates.io page, build status, and (eventually) docs

Resolves #3